### PR TITLE
Fix dropped final week in weekly trend granularity

### DIFF
--- a/src/TrendMetric.php
+++ b/src/TrendMetric.php
@@ -55,9 +55,17 @@ class TrendMetric extends Trend
     protected function getAggregateStartingDate(NovaRequest $request, string $unit, ?string $timezone): CarbonInterface
     {
         if ($request->filled('startDate') && $request->filled('endDate')) {
-            $this->custom_ending_date = CarbonImmutable::parse($request->input('endDate'), $timezone)->endOfDay();
+            $start = CarbonImmutable::parse($request->input('startDate'), $timezone)->startOfDay();
+            $end = CarbonImmutable::parse($request->input('endDate'), $timezone)->endOfDay();
 
-            return CarbonImmutable::parse($request->input('startDate'), $timezone)->startOfDay();
+            if ($unit === self::BY_WEEKS) {
+                $start = $start->startOfWeek();
+                $end = $end->endOfWeek();
+            }
+
+            $this->custom_ending_date = $end;
+
+            return $start;
         }
 
         $this->custom_ending_date = null;


### PR DESCRIPTION
When a trend aggregates by week, snap the custom start/end to whole ISO weeks so the step grid in getAllPossibleDateResults lines up with the %x-%v week buckets. A non-week-aligned start could overshoot the end date before landing in the final ISO week, so that week was never added to the possible results and its rows were rejected, dropping the last partial week from the chart.